### PR TITLE
Terminal/e4thcom dual-mode, lots of editing

### DIFF
--- a/Core
+++ b/Core
@@ -1,75 +1,31 @@
-RAM
-#require WIPE
-
-NVM
-
-\ nrf24L01+ registers and commands
-$07 constant R.STATUS
-$0A constant R.RX_ADDR_P0
-$10 constant R.TX_ADDR
-$11 constant R.RX_PW_P0
-$61 constant R_RX_PAYLOAD
-$A0 constant W_TX_PAYLOAD
-
-32 CONSTANT P0_WIDTH                 \ bytes in a payload. 1-32 bytes
-   VARIABLE mybuff P0_WIDTH ALLOT
-
-WIPE
+\ temporary dependencies
 
 #require ]B!
 #require ]C!
 
 \ definitions *********************************************
 
+\res MCU: STM8S103
+\res export BIT0 BIT1 BIT2 BIT3 BIT4 BIT5 BIT6 BIT7
+\res export SPI_CR1 SPI_CR2 SPI_DR SPI_SR
+\res export PC_ODR PC_DDR PC_CR1 PC_CR2
+\res export PD_ODR PD_DDR PD_CR1 PD_CR2
+
 \ nrf24L01+ registers and commands
-$00 constant R.CONFIG
-$E1 constant FLUSH_TX
-$E2 constant FLUSH_RX
-
-
-\ pins used
-
-3 constant _CSN \ pin _CSN on nRF24L01 connected to port D3
-2 constant _CE  \ pin _CE on nRF24L01 connected to port D2
-7 constant MISO \ C7
-6 constant MOSI \ c6
-5 constant _SCK \ c5
-4 constant _IRQ \ pin _IRQ on nRF24L01 connected to port C4
-
-\ constants for ports
-$500A constant PC_ODR
-$500B constant PC_IDR
-$500C constant PC_DDR
-$500D constant PC_CR1
-$500E constant PC_CR2
-$500F constant PD_ODR
-$5010 constant PD_IDR
-$5011 constant PD_DDR
-$5012 constant PD_CR1
-$5013 constant PD_CR2
-
-\ SPI registers
-$5200 constant SPI_CR1
-$5201 constant SPI_CR2
-$5204 constant SPI_DR
-$5203 constant SPI_SR
-
-\ Bits
-\ the datasheet uses the notation that Bit 1 is 0b00000010
-\ I normally think of bit1 being 0b00000001
-\ so I define Bit1 to Bit8 to avoid having to remember the
-\ datasheet representation
-\ Confused? Clearly I am.
-$1 constant  Bit0
-$2 constant  Bit1
-$4 constant  Bit2
-$8 constant  Bit3
-$10 constant  Bit4
-$20 constant  Bit5
-$40 constant  Bit6
-$80 constant  Bit7
+$00 CONSTANT R.CONFIG
+$E1 CONSTANT FLUSH_TX
+$E2 CONSTANT FLUSH_RX
 
 NVM
+
+\ nrf24L01+ registers and commands
+$07 CONSTANT R.STATUS
+$0A CONSTANT R.RX_ADDR_P0
+$10 CONSTANT R.TX_ADDR
+$11 CONSTANT R.RX_PW_P0
+$61 CONSTANT R_RX_PAYLOAD
+$A0 CONSTANT W_TX_PAYLOAD
+
 \ SPI Setup and Commands***********************************
 
 \ Init and enable SPI
@@ -83,38 +39,41 @@ NVM
 \ 00111100  = $3C
 
 : SPIon ( -- )
-  [ $0C SPI_CR1 ]C!  \ works for me with 4MHz SPI clock
-  [ $03 SPI_CR2 ]C!  \ no NSS, FD, no CRC, software slave, master
-  [ $4C SPI_CR1 ]C!  \ enable SPI
-;
+   [ $0C SPI_CR1 ]C!  \ works for me with 4MHz SPI clock
+   [ $03 SPI_CR2 ]C!  \ no NSS, FD, no CRC, software slave, master
+   [ $4C SPI_CR1 ]C!  \ enable SPI
+   ;
 
 : SPI ( c -- c )
-  [
-    $E601 ,                 \ LD   A,(1,X)
-    $C7 C,  SPI_DR ,        \ LD   SPI_DR,A
-    $7201 , SPI_SR , $FB C, \ BTJF SPI_SR,#SPIRXNE_WAIT (0)
-    $C6 C,  SPI_DR ,        \ LD   A,SPI_DR
-    $E701 ,                 \ LD   (1,X),A
-    $7F C, ]                \ CLR  (X)
-;
+   [  $E601 ,                 \ LD   A,(1,X)
+      $C7 C,  SPI_DR ,        \ LD   SPI_DR,A
+      $7201 , SPI_SR , $FB C, \ BTJF SPI_SR,#SPIRXNE_WAIT (0)
+      $C6 C,  SPI_DR ,        \ LD   A,SPI_DR
+      $E701 ,                 \ LD   (1,X),A
+      $7F C, ]                \ CLR  (X)
+   ;
 
 \ timing **************************************************
-
 \ delays seem close enough
-: D30us 11 FOR ( 2.5us per empty LOOP ) NEXT ;
-: D130us D30us D30us D30us D30us ;
-: 2ms  14 FOR D130us NEXT ;
-: 10ms  5 0 DO 2ms LOOP ;
+
+: D30us ( -- )  11 FOR ( 2.5us per empty LOOP ) NEXT ;
+
+: D130us ( -- ) D30us D30us D30us D30us ;
+
+: 2ms  ( -- )  14 FOR D130us NEXT ;
+
+: 10ms ( -- )  5 0 DO 2ms LOOP ;
+
 
 \ bit and variable manipulation ***************************
 
 : >LOW ( c1 bitn ---- c2 ) \ set bitn low
    NOT AND
-;
+   ;
 
 : >HIGH ( c1 bitn ---- c2 ) \ set bitn high
    OR
-;
+   ;
 
 : setup_pins ( -- )
    \ Port C inputs are floating, no interrupts enabled
@@ -124,29 +83,29 @@ NVM
    [ $60 ( 0b01100000 ) PC_DDR ]C!  \ port C outputs
    [ $60                PC_CR1 ]C!  \ set as push pull outputs
    [ $60                PC_CR2 ]C!  \ set as fast mode outputs
-;
+   ;
 
 : _CE.LOW ( -- )
-  [ 0 PD_ODR _CE ]B! D30us
-;
+   [ 0 PD_ODR _CE ]B! D30us
+   ;
 
 : _CE.High ( -- )
-  [ 1 PD_ODR _CE ]B! D30us
-;
+   [ 1 PD_ODR _CE ]B! D30us
+   ;
 
 : _CSN.LOW ( -- )
-  [ 0 PD_ODR _CSN ]B! D30us
-;
+   [ 0 PD_ODR _CSN ]B! D30us
+   ;
 
 : _CSN.High ( -- )
-  [ 1 PD_ODR _CSN ]B! D30us
-;
+   [ 1 PD_ODR _CSN ]B! D30us
+   ;
 
 \ talk to nRF24L01+ ***************************************
 
 : (nrf@!) ( c1 ---- )
-  _CE.LOW _CSN.LOW SPI  DROP
-;
+   _CE.LOW _CSN.LOW SPI  DROP
+   ;
 
 : nRF@n ( c2 c1 --- cN..C1 ) \ read c2 bytes
    (nrf@!)
@@ -154,131 +113,138 @@ NVM
       -1 SPI
    LOOP
    _CSN.High
-;
+   ;
 
 : nRF@1 ( c1 --- c2 ) \ fetch the contents of register c1
-    1 SWAP nRF@n
-;
+   1 SWAP nRF@n
+   ;
 
 \ Config register operations
 : nRF!_  ( c1 A1 --- c1 ) \ factored starting seq
    $20 OR
    (nrf@!) \ calling word must set _CSN high when finished sending data
-;
+   ;
 
 : nRF!0 ( c1 --- ) \ send command c1
    nRF!_
    D30us    \ TODO: won't work without a delay here - why?
    _CSN.High
-;
+   ;
 
-: nRF!n ( Cn....C1 A1 n --- ) \ write to nRF24 register A1 n bytes
+: nRF!n ( cn....c1 a1 n --- ) \ write to nRF24 register A1 n bytes
    SWAP
    nRF!_ \ sends address to write to
    0 DO
       SPI DROP
    LOOP
    _CSN.high
-;
+   ;
 
-: nRF!1
-  1 nRF!n
-;
+: nRF!1  ( c a -- )
+   1 nRF!n
+   ;
 
-: nRF!5
-  5 nRF!n
-;
+: nRF!5  ( c5....c1 a -- )
+   5 nRF!n
+   ;
 
-: IRQ@AND  ( c1 ---- f1 ) \ Get Interrupts then AND with C1
-   R.STATUS _csn.low SPI _csn.high AND \ cant use nRF@1 since it toggles _CE
-;
+: IRQ@AND  ( c1 ---- f1 )
+   \ Get Interrupts then AND with c1
+   R.STATUS _CSN.LOW SPI _CSN.HIGH AND   \ cant use nRF@1 since it toggles _CE
+   ;
 
-: TEST_INT ( c1 --- f1 )
-   DUP bit4 AND if ." Max retries cleared" cr -1 ELSE 0 THEN ( --- c1 f1 )
-   OVER Bit5 AND if ." Tx data sent" cr -1 ELSE 0 THEN OR
-   SWAP Bit6 AND if ." Rx data ready" cr -1 ELSE 0 THEN OR
-;
+: TEST_INT  ( c1 --- f1 )
+   DUP BIT4 AND IF ." Max retries cleared" CR -1 ELSE 0 THEN ( --- c1 f1 )
+   OVER BIT5 AND IF ." Tx data sent" CR -1 ELSE 0 THEN OR
+   SWAP BIT6 AND IF ." Rx data ready" CR -1 ELSE 0 THEN OR
+   ;
 
-: CLR_INT
+: CLR_INT  ( -- )
    R.STATUS nRF@1
    TEST_INT IF
      $70  R.STATUS nRF!1 \ 0b01110000
    THEN
-;
+   ;
 
-: RX_DR? Bit6 IRQ@AND ;
-: TX_DS? Bit5 IRQ@AND ;
-: MAX_RT? Bit4 IRQ@AND ;
-: RX_P_NO $0E IRQ@AND ; \ 0b00001110
-: TX_Full? bit0 IRQ@AND ;
+: RX_DR?  ( -- f )  BIT6 IRQ@AND ;
+
+: TX_DS?  ( -- f )  BIT5 IRQ@AND ;
+
+: MAX_RT?  ( -- f )  BIT4 IRQ@AND ;
+
+: RX_P_NO  ( -- c )  $0E IRQ@AND ; \ 0b00001110
+
+: TX_Full?  ( -- f )  BIT0 IRQ@AND ;
 
 \ lets setup nrf24L01+ how we want ************************
-: SetAddress \ LSB first
-   $E7 $D6 $C5 $B4 $A3 R.RX_ADDR_P0 nRF!5
-   $E7 $D6 $C5 $B4 $A3 R.TX_ADDR nRF!5
-;
 
-: SetPL_width \ bytes in rx payload
-   P0_width R.RX_PW_P0 nRF!1
-;
+: SetAddress  ( -- )  \ LSB first
+   $E7 $D6 $C5 $B4 $A3 R.RX_ADDR_P0  nRF!5
+   $E7 $D6 $C5 $B4 $A3 R.TX_ADDR     nRF!5
+   ;
 
-: R@Config  ( --- c1 ) \ fetch config reg
-   R.CONFIG nRF@1
-;
+: SetPL_width  ( c -- )  \ bytes in rx payload
+   P0_WIDTH R.RX_PW_P0  nRF!1
+   ;
 
-: R!Config ( c1 ----- ) \ write C1 to config reg
-   R.CONFIG nRF!1
-;
+: R@Config  ( -- c1 )  \ fetch config reg
+   R.CONFIG  nRF@1
+   ;
 
-: TX.PWR-18 ( -- )
-  \ SEt to -18dBm output and 250kbps
-   $0 bit5 >HIGH $06 nRF!1
-;
+: R!Config  ( c1 -- )  \ write C1 to config reg
+   R.CONFIG  nRF!1
+   ;
 
-: SetRetry \ use 750us retransmit delay, 15 retries
-  $8F $04 nRF!1 ;
-: myChannel  $70 5 nRF!1 ;
+: TX.PWR-18  ( -- )
+   \ SEt to -18dBm output and 250kbps
+   [ $0 BIT5 >HIGH ] LITERAL $06  nRF!1
+   ;
 
-: >Standby1
-  \ enter Standby state
-  _ce.low R@CONFIG   bit1 >HIGH R!CONFIG   2ms
-;
+: SetRetry  ( -- )  \ use 750us retransmit delay, 15 retries
+   $8F $04  nRF!1
+   ;
 
-: PWR.Dn ( -- )
-  _ce.low R@Config   bit1 >LOW R!CONFIG
-;
+: myChannel  ( -- )  $70 5 nRF!1 ;
 
-: FlushRx ( -- )
-  $E2 nRF!0
-;
+: >Standby1  ( -- )  \ enter Standby state
+   _CE.LOW R@CONFIG  BIT1 >HIGH R!CONFIG  2ms
+   ;
 
-: FlushTx ( -- )
-  $E1 nRF!0
-;
+: PWR.Dn  ( -- )
+   _CE.LOW R@Config  BIT1 >LOW R!CONFIG
+   ;
 
-: _CE.HD ( -- )
-  \ set CE high and pause
-  _ce.high D130us
-;
+: FlushRx  ( -- )
+   $E2 nRF!0
+   ;
 
-: Set.RX ( -- )
-  \ set as a receiver
-   R@Config bit0 >HIGH  R!CONFIG
-;
+: FlushTx  ( -- )
+   $E1 nRF!0
+   ;
 
-: Set.TX ( -- )
-  \ set as a transmitter
-   R@Config bit0 >LOW  R!CONFIG
-;
+: _CE.HD  ( -- )
+   \ set CE high and pause
+   _CE.HIGH D130us
+   ;
 
-: nRF24Init ( -- )
+: Set.RX  ( -- )
+   \ set as a receiver
+   R@Config BIT0 >HIGH  R!CONFIG
+   ;
+
+: Set.TX  ( -- )
+   \ set as a transmitter
+   R@Config BIT0 >LOW  R!CONFIG
+   ;
+
+: nRF24Init  ( -- )
    \ stuff we must do after a reset or power on
    setup_pins \ set up pins and SPI (RST)
-   SPIOn _CSN.high _CE.HD
-   9 FOR 10ms NEXT \ spec is 100ms
+   SPIOn _CSN.HIGH _CE.HD
+   9 FOR 10ms NEXT  \ spec is 100ms
    >Standby1
    SetAddress
-   SetPL_width     \ effectively enables Pipe0
+   SetPL_width      \ effectively enables Pipe0
    TX.PWR-18
    FlushRx
    FlushTx
@@ -286,18 +252,20 @@ NVM
    SetRetry
    myChannel
    ." Device reset" cr
-;
+   ;
 
 : (RX)
    nRF24Init   \ setup and go to standby1
    Set.RX      \ Will be a RX
    _CE.HD      \ Enter RX mode
-;
+   ;
 
 : (TX)
    nRF24Init   \ setup and go to standby1
    Set.TX      \ enter TX mode
    \ when is this required? >STANDBY1
-;
+   ;
+
 : .Ver ." 103" ;
+
 RAM

--- a/Depend
+++ b/Depend
@@ -1,0 +1,55 @@
+\ provide code compatibility for plain serial terminals (e.g. picocom)
+NVM
+
+\ ignore e4thcom source directives : #include [COMPILE] \ ; IMMEDIATE
+: #require [COMPILE] \ ; IMMEDIATE
+: \res     [COMPILE] \ ; IMMEDIATE
+
+\ essential immediate words
+: PERSIST NVM 'BOOT DUP $12 DUP ROT + SWAP CMOVE RAM ;
+: ]B! ROT 0= 1 AND SWAP 2* $10 + + $72 C, C, , ] ; IMMEDIATE
+: ]C! $35 C, SWAP C, , ] ; IMMEDIATE
+
+\ bit value definitions (otherwise available with \res export)
+$01 CONSTANT BIT0
+$02 CONSTANT BIT1
+$04 CONSTANT BIT2
+$08 CONSTANT BIT3
+$10 CONSTANT BIT4
+$20 CONSTANT BIT5
+$40 CONSTANT BIT6
+$80 CONSTANT BIT7
+
+\ STM8 port register addresses
+$5005 CONSTANT PB_ODR
+$5007 CONSTANT PB_DDR
+$5008 CONSTANT PB_CR1
+$5009 CONSTANT PB_CR2
+
+$500A CONSTANT PC_ODR
+$500B CONSTANT PC_IDR
+$500C CONSTANT PC_DDR
+$500D CONSTANT PC_CR1
+$500E CONSTANT PC_CR2
+
+$500F CONSTANT PD_ODR
+$5010 CONSTANT PD_IDR
+$5011 CONSTANT PD_DDR
+$5012 CONSTANT PD_CR1
+$5013 CONSTANT PD_CR2
+
+\ STM8S SPI register addresses
+$5200 CONSTANT SPI_CR1
+$5201 CONSTANT SPI_CR2
+$5204 CONSTANT SPI_DR
+$5203 CONSTANT SPI_SR
+
+\ Configuration
+
+3  CONSTANT _CSN \ pin _CSN on nRF24L01 connected to port D3
+2  CONSTANT _CE  \ pin _CE on nRF24L01 connected to port D2
+
+32 CONSTANT P0_WIDTH                 \ bytes in a payload. 1-32 bytes
+   VARIABLE mybuff P0_WIDTH ALLOT
+
+RAM PERSIST COLD

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 STM8EF_BOARD=MINDEV
-STM8EF_VER=2.2.22.pre2
+STM8EF_VER=2.2.22.pre3
 STM8EF_BIN=stm8ef-bin.zip
 STM8EF_URL=https://github.com/TG9541/stm8ef/releases/download/${STM8EF_VER}/${STM8EF_BIN}
 

--- a/Ping
+++ b/Ping
@@ -1,75 +1,87 @@
-\ changed $HW to erase buffer with spaces so that the count and retries saved into mybuff typed correctly at RX end
+\ changed $HW to erase buffer with spaces so that the count and
+\ retries saved into mybuff typed correctly at RX end
+
+\res MCU: STM8S103
+\res export BIT0 BIT1 BIT2 BIT3 BIT4 BIT5 BIT6 BIT7
+\res export PB_ODR PB_DDR PB_CR1 PB_CR2NVM
+
 NVM
-: $HW
-  mybuff P0_width $20 fill \ erase buffer
-  $" Hello World" count ( --- a1 n1 )
-  mybuff swap CMOVE
+
+: $HW  ( -- )
+   mybuff P0_width $20 FILL \ erase buffer
+   $" Hello World" COUNT  ( --- a1 n1 )
+   mybuff SWAP CMOVE
+   ;
+
+5 CONSTANT _LED \ Led connected to port B, Pin 5
+
+: Setup_B  ( -- )
+   BIT5 PB_DDR C! \ Port B outputs
+   BIT5 PB_CR1 C! \ set up as push pull outputs
 ;
 
-5 constant _LED \ Led connected to port B, Pin 5
-$5005 constant PB_ODR
-$5006 constant PB_IDR
-$5007 constant PB_DDR
-$5008 constant PB_CR1
+: LED.On  ( -- )  [ 0 PB_ODR _LED ]B! ;
 
-: Setup_B
-   Bit5 PB_DDR c! \ Port B outputs
-   Bit5 PB_CR1 c! \ set up as push pull outputs
-;
-: LED.On ( -- )  [ 0 PB_ODR _LED ]B! ;
-: LED.Off ( -- ) [ 1 PB_ODR _LED ]B! ;
-: @retries ( --- n1 )
+: LED.Off  ( -- ) [ 1 PB_ODR _LED ]B! ;
+
+: @retries  ( --- n1 )
    $08 nRF@1   \ get count of lost packets:retries
    $0F AND     \ mask off lost packets
-;   
-: FlashLed
-   16 swap - 0
-   do
-      LED.ON 
-      10ms 
+;
+
+: FlashLed  ( -- )
+   16 SWAP - 0
+   DO
+      LED.ON
+      10ms
       LED.Off
       10ms 10ms 10ms 10ms
-   loop
+   LOOP
    ;
-: PAYLOAD.TX \ send n bytes as set by P0_width
+
+: PAYLOAD.TX  ( -- )  \ send n bytes as set by P0_width
    SET.TX
    $A0 (NRF@!) \ Send Loading tx buffer, drop status reply
-   P0_width 0 do  \ Loading tx buffer
-      I mybuff + c@
-      spi drop
-   loop        \ tx n bytes from mybuff
+   P0_WIDTH 0 DO  \ Loading tx buffer
+      I mybuff + C@
+      SPI DROP
+   LOOP        \ tx n bytes from mybuff
    _CSN.High
    _CE.HD   \ 10us minimum, using 130uS
-   _CE.low
+   _CE.LOW
    10ms  10ms        \ allow time for packet to be sent and processed.
    10ms  10ms        \ Timing depends on what Rx is doing with payload
-   clr_int
-;
-: TX.PWR0 \ SEt to 0dBm output and 250kbps
-     $0 bit5 >high bit2 >high bit1 >high $06 nRF!1
-;
-: n>str <# #s #>  \ ( n1 --- a1 n2 )
-;
+   CLR_INT
+   ;
+
+: TX.PWR0  ( -- )  \ SEt to 0dBm output and 250kbps
+   [ $0 BIT5 >HIGH BIT2 >HIGH BIT1 >HIGH ] LITERAL $06 nRF!1
+   ;
+
+: n>str  ( n1 --- a1 n2 )  <# #s #> ;
+
 : n>buff ( a1 n1 --- ) \ store n1 as a string at offset n1 in mybuff
-   n>str \ a1 a2 n2 
-   rot mybuff + 
-   swap
-   cmove
-;   
-: Ping1
+   n>str \ a1 a2 n2
+   ROT mybuff +
+   SWAP
+   CMOVE
+   ;
+
+: Ping1  ( -- )
    (TX)
    TX.PWR0
    $HW
    Setup_B
-   150 0 do
+   150 0 DO
       20 I n>buff
-      payload.tx
+      PAYLOAD.TX
       @retries
-      dup 
-      27 swap n>buff
+      DUP
+      27 SWAP n>buff
       FlashLed
-      100 0 do 10ms loop
-   loop
-;
-' ping1 'Boot !  
+      100 0 DO 10ms LOOP
+   LOOP
+   ;
+
+' Ping1 'Boot !
 RAM

--- a/Pong
+++ b/Pong
@@ -1,61 +1,73 @@
+\res MCU: STM8S103
+\res export BIT0 BIT1 BIT2 BIT3 BIT4 BIT5 BIT6 BIT7
+\res export PB_ODR PB_DDR PB_CR1 PB_CR2
+
+#require ]B!
+
 NVM
-5 constant _LED \ Led connected to port B, Pin 5
-$5005 constant PB_ODR
-$5007 constant PB_DDR
-$5008 constant PB_CR1
-: Setup_B
-   BIT5 PB_DDR c! \ Port B outputs
-   BIT5 PB_CR1 c! \ set up as push pull outputs
-;
-: LED.On ( -- )  [ 0 PB_ODR _LED ]B! ;
-: LED.Off ( -- ) [ 1 PB_ODR _LED ]B! ;
-: FlashLed  LED.ON 2ms LED.Off   
-;
-: TX.PWR0 \ SEt to 0dBm output and 250kbps
-     $0 BIT5 >high BIT2 >high BIT1 >high $06 nRF!1
-;
-: PAYLOAD.RX ( ---- n1 n2 ... nn ) \ returns n bytes as set by P0_width
+
+5 CONSTANT _LED   \ Led connected to port B, Pin 5
+
+: Setup_B  ( -- )
+   BIT5 PB_DDR C!  \ Port B outputs
+   BIT5 PB_CR1 C!  \ set up as push pull outputs
+   ;
+
+: LED.On  ( -- )  [ 0 PB_ODR _LED ]B! ;
+
+: LED.Off  ( -- )  [ 1 PB_ODR _LED ]B! ;
+
+: FlashLed  ( -- )  LED.ON 2ms LED.Off ;
+
+: TX.PWR0  ( -- )  \ SEt to 0dBm output and 250kbps
+   [ $0 BIT5 >HIGH BIT2 >HIGH BIT1 >HIGH ] LITERAL $06 nRF!1
+   ;
+
+: PAYLOAD.RX  ( -- n1 n2 ... nn )  \ returns n bytes as set by P0_width
    BEGIN
-      rx_dr? \ wait until data is ready
+      RX_DR?  \ wait until data is ready
    UNTIL
-    >STANDBY1
-   R_RX_PAYLOAD (NRF@!) \ sends command "get bytes in the payload"
-   P0_WIDTH 0 
+   >STANDBY1
+   R_RX_PAYLOAD (NRF@!)  \ sends command "get bytes in the payload"
+   P0_WIDTH 0
    DO
-      $ff SPI
-      MYBUFF I + c!
+      $FF SPI
+      MYBUFF I + C!
    LOOP
-   _csn.high 
-   BIT6 R.STATUS nRF!1 
+   _CSN.HIGH
+   BIT6 R.STATUS nRF!1
    CLR_INT
-   _CE.HD \ go back to being a RX
+   _CE.HD  \ go back to being a RX
    ;
-: TESTRX
+
+: TESTRX  ( -- )
    (RX) \ now acting as a RX
-   _ce.low
+   _CE.LOW
    TX.PWR0
-   _ce.high
+   _CE.HIGH
    BEGIN
-      rx_dr?
-      IF  
+      RX_DR?
+      IF
          PAYLOAD.RX
-         MYBUFF P0_WIDTH type cr
+         MYBUFF P0_WIDTH TYPE CR
       THEN
-      ?RX \ input on serial line 
-      IF 32 = ELSE 0 THEN \ only if it is a space char do we exit
+      ?RX  \ input on serial line
+      IF 32 = ELSE 0 THEN  \ only if it is a space char do we exit
    UNTIL
    ;
- \ on power up flash led so we know device is a pong
-: Pong
+
+: Pong  ( -- )  \ on power up flash led so we know device is a pong
    Setup_B
-   Led.On 10ms  
-   Led.Off 
-   50 0  
-   DO 
-      10ms 
-   LOOP 
+   Led.On 10ms
+   Led.Off
+   50 0
+   DO
+      10ms
+   LOOP
    FlashLed
    TESTRX
    ;
-' PONG 'Boot !  
+
+' Pong 'Boot !
+
 RAM

--- a/main.fs
+++ b/main.fs
@@ -1,3 +1,13 @@
+#require WIPE
+NVM
+32 CONSTANT P0_WIDTH                 \ bytes in a payload. 1-32 bytes
+   VARIABLE mybuff P0_WIDTH ALLOT
+WIPE
+
+3 CONSTANT _CSN \ pin _CSN on nRF24L01 connected to port D3
+2 CONSTANT _CE  \ pin _CE on nRF24L01 connected to port D2
+
 #include Core
+
 #require WIPE
 WIPE


### PR DESCRIPTION
Hi Richard,
this pull request has three goals:
1. allow efficient program/edit cycle even without e4thcom
2. split library code, board configuration, and application (work in progress)
3. editing: allow usage in a case-sensitive systems, try to use "Brody style"

1.) will speed up your programming cycle with "dumb terminals" quite a bit
It works in the following way:
* flash the STM8 eForth binary (e.g. MINDEV.ihx)
* transfer Depend (which words normally loaded with #require or \res, and makes Forth ignore #require etc
* Depend creates a persistent vocabulary
* transfer Core and run PERSIST (unless you're coding/testing Core, of course)
* transfer the application code, e.g. Ping

2.) I'm trying to find a way for splitting core code from configuration, ans application code from the latter.  This is a bit tricky.

3.) Uniform formatting is nitpicking but lower/uppercase is a question of compatibility with the CORE binary.